### PR TITLE
Minor tweaks to existing docs, added Table of Content examples, added TODOs

### DIFF
--- a/content/document-definition-object/qr.md
+++ b/content/document-definition-object/qr.md
@@ -21,7 +21,7 @@ var docDefinition = {
 ```
 
 Properties:
-
+<!-- TODO add descriptons for these properties. It will be nice to add these to the @types/pdfmake too -->
 * _qr_ - text in QR code
 * _foreground_ (optional) -
 * _background_ (optional) -

--- a/content/document-definition-object/styling.md
+++ b/content/document-definition-object/styling.md
@@ -58,7 +58,7 @@ To have a deeper understanding of styling in pdfmake, style inheritance and loca
 
 #### Default style
 
-And is also possible define default style:
+And it is also possible to define a default style:
 
 ```js
 var docDefinition = {
@@ -85,16 +85,11 @@ var docDefinition = {
 * `color: string`: the color of the text (color name e.g., 'blue' or hexadecimal color e.g., '#ff5500')
 * `background: string` the background color of the text
 * `markerColor: string`: the color of the bullets in a buletted list
-* `decoration: string`: the text decoration to applu ('underline' or 'lineThrough' or 'overline')
-* `decorationStyle: string`: ('dashed' or 'dotted' or 'double' or 'wavy')
+* `decoration: string`: the text decoration to apply ('underline' or 'lineThrough' or 'overline')
+* `decorationStyle: string`: the style of the text decoration ('dashed' or 'dotted' or 'double' or 'wavy')
 * `decorationColor: string`: the color of the text decoration, see color
 
 ##### Table-cell properties
-* `fillColor: string`: the background color of a table cell
 * `columnGap`
-* `tableCellPadding`
-* `cellBorder`
-* `headerCellBorder`
-* `oddRowCellBorder`
-* `evenRowCellBorder`
-* `tableBorder`
+* `fillColor: string`: the background color of a table cell
+* `fillOpacity: string`: the background opacity of a table cell

--- a/content/document-definition-object/styling.md
+++ b/content/document-definition-object/styling.md
@@ -90,6 +90,7 @@ var docDefinition = {
 * `decorationColor: string`: the color of the text decoration, see color
 
 ##### Table-cell properties
+<!-- TODO add description for columnGap -->
 * `columnGap`
 * `fillColor: string`: the background color of a table cell
 * `fillOpacity: string`: the background opacity of a table cell

--- a/content/document-definition-object/toc.md
+++ b/content/document-definition-object/toc.md
@@ -5,21 +5,61 @@ weight = 292
 alwaysopen = true
 +++
 
-
+The simplest example of a table of contents:
 ```js
 var docDefinition = {
   content: [
     {
       toc: {
-        // id: 'mainToc'  // optional
         title: {text: 'INDEX', style: 'header'}
       }
     },
     {
       text: 'This is a header',
       style: 'header',
-      tocItem: true, // or tocItem: 'mainToc' if is used id in toc
-      // or tocItem: ['mainToc', 'subToc'] for multiple tocs
+      tocItem: true,
+    }
+  ]
+}
+```
+
+If `id` is used in toc, the tocItem can target that id:
+```js
+var docDefinition = {
+  content: [
+    {
+      toc: {
+        id: 'mainToc'
+        title: {text: 'INDEX', style: 'header'}
+      }
+    },
+    {
+      text: 'This is a header',
+      style: 'header',
+      tocItem: 'mainToc'
+    }
+  ]
+}
+```
+
+If multiple Table of Contents are used, tocItem can be used to place the text in the correct toc:
+```js
+var docDefinition = {
+  content: [
+    {
+      toc: {
+        id: 'mainToc'
+        title: {text: 'INDEX', style: 'header'}
+      },
+      toc: {
+        id: 'subToc'
+        title: {text: 'SUB INDEX', style: 'header'}
+      }
+    },
+    {
+      text: 'This is a header',
+      style: 'header',
+      tocItem: ['mainToc', 'subToc']
     }
   ]
 }

--- a/content/fonts/icons.md
+++ b/content/fonts/icons.md
@@ -7,7 +7,7 @@ alwaysopen = true
 
 - make a font at http://fontello.com/ or something and download it
 
-- from font file (for example .ttf) create vfs_fonts.js file, [use custom fonts](/docs/fonts/custom-fonts-client-side/#1-create-a-new-vfs-fonts-js-containing-your-font-files))
+- from font file (for example .ttf) create vfs_fonts.js file (see how to [use custom fonts](/docs/fonts/custom-fonts-client-side/#1-create-a-new-vfs-fonts-js-containing-your-font-files))
 
 - define font in js (just defining normal might be enough):
     ```js


### PR DESCRIPTION
I'm reviewing @types/pdfmake and while doing so, I'm also reviewing the docs. I noticed some differences here that needed tidied up.

The Table-cell properties that I'm removing are ones that I noticed are commented out in the [styleContentStack.js](https://github.com/bpampuch/pdfmake/blob/master/src/StyleContextStack.js) so I don't think they add any value to the docs.

I wasn't able to add an accurate comment for `fontFeatures` or `columnGap`. If someone could give me direction as to how to describe these styles, then we could add them to the docs. 