### PR TITLE
Add rollup instructions

### DIFF
--- a/content/getting-started/client-side/_index.md
+++ b/content/getting-started/client-side/_index.md
@@ -79,6 +79,16 @@ exclude: [ /node_modules/, /pdfmake.js$/ ]
 ```
 (see [issue](https://github.com/bpampuch/pdfmake/issues/1100#issuecomment-336728521))
 
+If you are using rollup, and a **Cannot read property 'pdfMake' of undefined at vfs_fonts.js** error is thrown, add this to rollup config:
+```js
+moduleContext: {
+  './node_modules/pdfmake/build/vfs_fonts.js': 'window',
+},
+```
+Then, if console outputs a **Illegal reassignment to import 'pdfMake'**, do not assign vfs manually, just import fonts like this:
+```js
+import 'pdfmake/build/vfs_fonts';
+```
 
 #### Repository
 


### PR DESCRIPTION
Using rollup as a project bundler introduces two problems with pdfmake:
1. rollup won't allow for reassigning imported module (see [issue](https://github.com/rollup/rollup/issues/436)), so there is no way to assign vfs fonts manually.
2. rollup won't parse vfs_fonts.js, since it uses `this` at top level, with is by default set by rollup to `undefined` (see [docs](https://rollupjs.org/guide/en/#error-this-is-undefined))

To resolve both issues, `this` for pdfmake needs to be set to `window`, with `options.moduleContext` in rollup config, and then fonts assignments needs to happen before importing pdfmake to rollup scope (fortunately, since `this` in vfs_fonts is now `window`, it will do the assignment automatically).