### PR TITLE
fixed font vfs generation script on macos

### DIFF
--- a/content/fonts/custom-fonts-client-side/vfs/shell.md
+++ b/content/fonts/custom-fonts-client-side/vfs/shell.md
@@ -20,20 +20,18 @@ else
 fi
 
 (
-	echo -n "this.pdfMake = this.pdfMake || {}; this.pdfMake.vfs = {"
+	echo "this.pdfMake = this.pdfMake || {}; this.pdfMake.vfs = {"
 	for file in "$@"; do
 		file=$1
+		filename=$(basename $file)
+		filecontent=$(base64 -w 0 $file)
 		shift
-		echo -n '"'
-		echo -n "$(basename $file)"
-		echo -n '":"'
-		echo -n "$(base64 -w 0 $file)"
-		echo -n '"'
+		echo "\"${filename}\":\"${filecontent}\""
 		if [ "$#" -gt 0 ]; then
-			echo -n ","
+			echo ","
 		fi
 	done
-	echo -n "};"
+	echo "};"
 ) > "$target"
 ```
 
@@ -44,13 +42,13 @@ script.sh font1.ttf font2.ttf font3.ttf
 
 If you are using a mac you need to change this line
 ```
-		echo -n "$(base64 -w 0 $file)"
+		filecontent=$(base64 -w 0 $file)
 ```
 
 to (change the flag from `-w` to `-b`)
 
 ```
-		echo -n "$(base64 -b 0 $file)"
+		filecontent=$(base64 -b 0 $file)
 ```
 
 GNU coreutils' `base64` seems to differ to Apple's `base64` in this flag (which prevents line wrapping).


### PR DESCRIPTION
On macOS the shell script does not produce usable output. The `-n` is present in the resulting js file which causes the newlines to be present as well which then causes the js file to be invalid. The "oneliner" echo version with variables does work in macOS, however. (I changed the `-b` back to `-w` here)

If this also works on other OS, it might be worth to change in the example code.