### PR TITLE
docs: add warning for empty nodes

### DIFF
--- a/content/document-definition-object/images.md
+++ b/content/document-definition-object/images.md
@@ -10,6 +10,8 @@ This is simple. Just use the ```{ image: '...' }``` node type.
 
 JPEG and PNG formats are supported.
 
+{{% alert theme="warning" %}}The image node expects a valid image value. If the value is invalid or empty, an error is thrown.{{% /alert %}}
+
 ```js
 var docDefinition = {
   content: [

--- a/content/document-definition-object/svgs.md
+++ b/content/document-definition-object/svgs.md
@@ -7,6 +7,8 @@ alwaysopen = true
 
 SVGs are much like [images](/docs/0.3/document-definition-object/images/) except it is not currently possible to refer to SVGs by file or re-use from a dictionary.
 
+{{% alert theme="warning" %}}The SVG node expects a valid SVG value. If the value is invalid or empty, an error is thrown.{{% /alert %}}
+
 Library [SVG-to-PDFKit](https://github.com/alafr/SVG-to-PDFKit) is used to transformation from SVG to PDF document.
 
 ```js

--- a/content/document-definition-object/tables.md
+++ b/content/document-definition-object/tables.md
@@ -8,6 +8,8 @@ alwaysopen = true
 
 Conceptually tables are similar to columns. They can however have headers, borders and cells spanning over multiple columns/rows.
 
+{{% alert theme="warning" %}}The table node expects a valid table value. If the value is invalid or empty, an error is thrown. This includes the table.body property as well.{{% /alert %}}
+
 ```js
 var docDefinition = {
   content: [


### PR DESCRIPTION
## Description

This PR adds warning banners to the following node types:
- image
- svg
- table

The warning explains the requirements for the node types and mentions the potential to throw during the runtime.
 
## Preview

![image](https://user-images.githubusercontent.com/77127505/233357738-ccf1e5de-cdde-413b-bd42-6d0d55b50953.png)

## Additional information

Requested in https://github.com/bpampuch/pdfmake/issues/2562#issuecomment-1505457845